### PR TITLE
feat: support converting images in a web worker

### DIFF
--- a/formats-browser.js
+++ b/formats-browser.js
@@ -1,27 +1,10 @@
-const initializeCanvas = ({ width, height }) => {
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-
-  return canvas;
-};
-
-const convert = async ({ data, width, height }, ...blobArgs) => {
-  const canvas = initializeCanvas({ width, height });
+const convert = async ({ data, width, height }, type, quality) => {
+  const canvas = new OffscreenCanvas(width, height);
 
   const ctx = canvas.getContext('2d');
   ctx.putImageData(new ImageData(data, width, height), 0, 0);
 
-  const blob = await new Promise((resolve, reject) => {
-    canvas.toBlob(blob => {
-      if (blob) {
-        return resolve(blob);
-      }
-
-      return reject(new Error('failed to convert the image'));
-    }, ...blobArgs);
-  });
-
+  const blob = await canvas.convertToBlob({ type, quality })
   const arrayBuffer = await blob.arrayBuffer();
 
   return new Uint8Array(arrayBuffer);


### PR DESCRIPTION
Use `OffscreenCanvas` to decouple image conversion from the DOM, allowing execution in a web worker to unblock the main thread.