### PR TITLE
feat: add browser export

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.1.0",
   "description": "Convert HEIC/HEIF images to JPEG and PNG",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./browser": "./browser.js"
+  },
   "scripts": {
     "pretest": "node scripts/images.js",
     "test": "mocha --timeout 40000 --slow 0 \"test/**/*.test.js\""


### PR DESCRIPTION
When I try to use the browser submodule: import convert from 'heic-convert/browser' with TypeScript, there is an error about missing type definitions, so I created the type definitions for the browser submodule: 

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69983

But it also requires adding the exports field to the package.json to tell the NodeJS engine that there is a submodule called `browser`.

References:

https://nodejs.org/api/packages.html#subpath-exports
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69983#discussion_r1688729326